### PR TITLE
fix(generator): keep the selector on conditional token rules

### DIFF
--- a/.changeset/lucky-moons-shave.md
+++ b/.changeset/lucky-moons-shave.md
@@ -1,0 +1,34 @@
+---
+'@bamboocss/generator': patch
+'@bamboocss/fixture': patch
+'@bamboocss/postcss': patch
+'@bamboocss/core': patch
+'@bamboocss/node': patch
+---
+
+Fix conditional token values being silently dropped on postcss `>= 8.5.25`.
+
+A semantic token declared with a conditional value emitted only its `base` half — no error, no warning — so a themed app
+kept its light values in dark mode:
+
+```ts
+semanticTokens: {
+  colors: {
+    panel: { value: { base: '#ffffff', _osDark: '#131211' } },
+  },
+}
+```
+
+```css
+/* before — the `_osDark` half never reached the tokens layer */
+@layer tokens {
+  :where(:root, :host) {
+    --colors-panel: #ffffff;
+  }
+}
+```
+
+`getDeepestRule` seeded its nesting chain with an empty-selector rule and relied on postcss-nested erasing `&` against
+it. postcss 8.5.25 ("Fixed 8.5.17 visitor regression") changed that edge case to collapse the whole selector, so every
+conditional token was emitted as a selectorless — and therefore discarded — rule. The chain is now built on a `Root`,
+and the top-level `&` is resolved directly instead of through postcss-nested.

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,7 +47,7 @@
     "browserslist": "4.28.1",
     "lodash.merge": "4.6.2",
     "outdent": "0.8.0",
-    "postcss": "8.5.14",
+    "postcss": "8.5.25",
     "postcss-discard-duplicates": "7.0.2",
     "postcss-discard-empty": "7.0.1",
     "postcss-minify-selectors": "7.0.5",

--- a/packages/fixture/package.json
+++ b/packages/fixture/package.json
@@ -17,6 +17,6 @@
     "@bamboocss/shared": "workspace:^",
     "@bamboocss/token-dictionary": "workspace:^",
     "@bamboocss/types": "workspace:*",
-    "postcss": "8.5.14"
+    "postcss": "8.5.25"
   }
 }

--- a/packages/generator/__tests__/generate-themes.test.ts
+++ b/packages/generator/__tests__/generate-themes.test.ts
@@ -53,7 +53,7 @@ describe('generate themes', () => {
           "json": "{
         "name": "default",
         "id": "bamboo-theme-default",
-        "css": "[data-bamboo-theme=default] {\\n    --colors-primary: blue;\\n    --colors-simple: var(--colors-red-600);\\n    --colors-text: var(--colors-blue-600)\\n}\\n\\n@media (prefers-color-scheme: dark) {\\n      [data-bamboo-theme=default] {\\n        --colors-text: var(--colors-blue-400)\\n            }\\n        }"
+        "css": "[data-bamboo-theme=default] {\\n  --colors-primary: blue;\\n  --colors-simple: var(--colors-red-600);\\n  --colors-text: var(--colors-blue-600)\\n}\\n\\n@media (prefers-color-scheme: dark) {\\n    [data-bamboo-theme=default] {\\n      --colors-text: var(--colors-blue-400)\\n        }\\n    }"
       }",
           "name": "theme-default",
         },
@@ -61,7 +61,7 @@ describe('generate themes', () => {
           "json": "{
         "name": "pink",
         "id": "bamboo-theme-pink",
-        "css": "[data-bamboo-theme=pink] {\\n    --colors-primary: pink;\\n    --colors-text: var(--colors-pink-600)\\n}\\n\\n@media (prefers-color-scheme: dark) {\\n      [data-bamboo-theme=pink] {\\n        --colors-text: var(--colors-pink-400)\\n            }\\n        }"
+        "css": "[data-bamboo-theme=pink] {\\n  --colors-primary: pink;\\n  --colors-text: var(--colors-pink-600)\\n}\\n\\n@media (prefers-color-scheme: dark) {\\n    [data-bamboo-theme=pink] {\\n      --colors-text: var(--colors-pink-400)\\n        }\\n    }"
       }",
           "name": "theme-pink",
         },

--- a/packages/generator/__tests__/generate-token.test.ts
+++ b/packages/generator/__tests__/generate-token.test.ts
@@ -1,5 +1,6 @@
 import { createContext } from '@bamboocss/fixture'
 import type { Config } from '@bamboocss/types'
+import postcss from 'postcss'
 import { describe, expect, test } from 'vitest'
 
 const tokenCss = (config?: Config) => {
@@ -544,7 +545,7 @@ describe('generator', () => {
 
         [data-color=material]:where([data-theme=dark], .dark) {
           --colors-surface: #m-d
-              }
+          }
 
         [data-color=pastel] {
           --colors-surface: #p-b
@@ -553,20 +554,20 @@ describe('generator', () => {
         @media screen and (min-width: 48rem) {
           [data-color=pastel]:where([data-theme=dark], .dark) {
             --colors-surface: #p-d
-                      }
                   }
+              }
 
         @media screen and (min-width: 64rem) {
           :where(html) {
             --spacing-gutter: var(--spacing-5)
-              }
           }
+      }
 
         @media (forced-colors: active) {
           :where([data-theme=dark], .dark) {
             --colors-complex: var(--colors-red-700)
-                  }
               }
+          }
       }"
     `)
   })
@@ -974,8 +975,8 @@ describe('generator', () => {
         @media (prefers-color-scheme: dark) {
           :where(html) {
             --colors-body: var(--colors-blue-400)
-              }
           }
+      }
       }"
     `)
   })
@@ -1048,11 +1049,11 @@ describe('generator', () => {
         @media (prefers-color-scheme: dark) {
           :where(html) {
             --colors-body: var(--colors-blue-400)
-              }
+          }
           [data-bamboo-theme=primary] {
             --colors-body: var(--colors-red-400)
-                  }
-          }
+              }
+      }
       }"
     `)
   })
@@ -1143,11 +1144,11 @@ describe('generator', () => {
         @media (prefers-color-scheme: dark) {
           :where(html) {
             --colors-body: var(--colors-blue-400)
-              }
+          }
           [data-bamboo-theme=primary] {
             --colors-body: var(--colors-red-400)
-                  }
-          }
+              }
+      }
       }"
     `)
   })
@@ -1220,11 +1221,11 @@ describe('generator', () => {
         @media (prefers-color-scheme: dark) {
           :where(html) {
             --colors-body: var(--colors-blue-400)
-              }
+          }
           [data-bamboo-theme=primary] {
             --colors-body: var(--colors-red-400)
-                  }
-          }
+              }
+      }
       }"
     `)
   })
@@ -1306,14 +1307,14 @@ describe('generator', () => {
         @media (hover: hover) {
           :is(:hover, [data-hover]) {
             --colors-accent: var(--colors-blue-500)
-                  }
-          }
+              }
+      }
 
         @media (hover: none) {
           :is(:active, [data-active]) {
             --colors-accent: var(--colors-blue-500)
-                  }
-          }
+              }
+      }
       }"
     `)
   })
@@ -1363,14 +1364,14 @@ describe('generator', () => {
         @media (hover: hover) {
           .dark:is(:hover, [data-hover]) {
             --colors-accent: var(--colors-zinc-700)
-                      }
-              }
+                  }
+          }
 
         @media (hover: none) {
           .dark:is(:active, [data-active]) {
             --colors-accent: var(--colors-zinc-700)
-                      }
-              }
+                  }
+          }
       }"
     `)
   })
@@ -1422,33 +1423,33 @@ describe('generator', () => {
           @media (prefers-color-scheme: light) {
             :is(:hover, [data-hover])[data-mode="light"] {
               --colors-accent: var(--colors-blue-500)
-                              }
-                      }
-          }
+                          }
+                  }
+      }
 
         @media (hover: hover) {
           @media (prefers-color-scheme: dark) {
             :is(:hover, [data-hover])[data-mode="dark"] {
               --colors-accent: var(--colors-blue-500)
-                              }
-                      }
-          }
+                          }
+                  }
+      }
 
         @media (hover: none) {
           @media (prefers-color-scheme: light) {
             :is(:active, [data-active])[data-mode="light"] {
               --colors-accent: var(--colors-blue-500)
-                              }
-                      }
-          }
+                          }
+                  }
+      }
 
         @media (hover: none) {
           @media (prefers-color-scheme: dark) {
             :is(:active, [data-active])[data-mode="dark"] {
               --colors-accent: var(--colors-blue-500)
-                              }
-                      }
-          }
+                          }
+                  }
+      }
       }"
     `)
   })
@@ -1491,6 +1492,52 @@ describe('generator', () => {
 
         [data-theme="dark"],[data-dark-theme] {
           --colors-surface: var(--colors-zinc-700)
+      }
+      }"
+    `)
+  })
+
+  test('conditional semantic tokens keep their selector', () => {
+    const config: Config = {
+      eject: true,
+      conditions: {
+        osDark: '@media (prefers-color-scheme: dark)',
+        dark: '.dark &',
+      },
+      theme: {
+        semanticTokens: {
+          colors: {
+            panel: { value: { base: '#ffffff', _osDark: '#131211' } },
+            ink: { value: { base: '#131211', _dark: '#ffffff' } },
+          },
+        },
+      },
+    }
+
+    const css = tokenCss(config)
+
+    // A rule that loses its selector is dropped by every downstream parser, so the
+    // conditional value disappears with no error. Guard the invariant directly:
+    // the conditional halves must reach the output, each under a real selector.
+    postcss.parse(css).walkRules((rule) => {
+      expect(rule.selector.trim()).not.toBe('')
+    })
+
+    expect(css).toMatchInlineSnapshot(`
+      "@layer tokens {
+        :where(html) {
+          --colors-panel: #ffffff;
+          --colors-ink: #131211;
+      }
+
+        .dark {
+          --colors-ink: #ffffff
+      }
+
+        @media (prefers-color-scheme: dark) {
+          :where(html) {
+            --colors-panel: #131211
+          }
       }
       }"
     `)

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -47,7 +47,7 @@
     "javascript-stringify": "2.1.0",
     "outdent": " ^0.8.0",
     "pluralize": "8.0.0",
-    "postcss": "8.5.14",
+    "postcss": "8.5.25",
     "ts-pattern": "5.9.0"
   },
   "devDependencies": {

--- a/packages/generator/src/artifacts/css/token-css.ts
+++ b/packages/generator/src/artifacts/css/token-css.ts
@@ -2,7 +2,7 @@ import type { Conditions, Context } from '@bamboocss/core'
 import { Stylesheet, expandNestedCss, extractParentSelectors, stringify } from '@bamboocss/core'
 import { logger } from '@bamboocss/logger'
 import type { ConditionQuery } from '@bamboocss/types'
-import postcss, { AtRule, CssSyntaxError, Rule } from 'postcss'
+import postcss, { Container, CssSyntaxError } from 'postcss'
 
 export function generateTokenCss(ctx: Context, sheet: Stylesheet) {
   const { config, conditions, tokens } = ctx
@@ -141,29 +141,48 @@ function transformSegment(seg: string): string {
   return parent ? `&${parent}` : seg
 }
 
+/**
+ * Build the nesting chain for one condition path.
+ *
+ * The outermost node is a `Root`, so the first segment has no enclosing rule and
+ * its `&` refers to nothing — it is resolved away here rather than by
+ * postcss-nested. Deeper segments keep their `&` and nest against the real
+ * parent selector as before.
+ *
+ * This used to be seeded with an empty-selector rule and leaned on
+ * postcss-nested to erase `&` against it. postcss 8.5.25 ("Fixed 8.5.17 visitor
+ * regression") changed that edge case to collapse the whole selector, so every
+ * conditional token was emitted as a selectorless — and therefore discarded —
+ * rule, leaving only the `base` value in the tokens layer.
+ */
 function getDeepestRule(root: string, selectors: string[]) {
-  const rule = postcss.rule({ selector: '' })
+  const container = postcss.root()
 
   for (const selector of selectors) {
-    const last = getDeepestNode(rule)
-    const node = last ?? rule
+    const node = getDeepestNode(container)
+    const isTopLevel = node === container
     if (selector.startsWith('@')) {
       // ASSUMPTION: the nature of parent selectors with tokens is that they're merged
       // [data-color-mode=dark][data-theme=pastel]
       // If we really want it nested, we remove the `&`
-      const atRule = postcss.rule({ selector, nodes: [postcss.rule({ selector: `${root}&` })] })
+      const inner = isTopLevel ? root : `${root}&`
+      const atRule = postcss.rule({ selector, nodes: [postcss.rule({ selector: inner })] })
       node.append(atRule)
     } else {
-      node.append(postcss.rule({ selector }))
+      node.append(postcss.rule({ selector: isTopLevel ? withoutParentSelector(selector) : selector }))
     }
   }
 
-  return rule
+  return container
 }
 
-function getDeepestNode(node: AtRule | Rule): Rule | AtRule | undefined {
+function withoutParentSelector(selector: string) {
+  return selector.replaceAll('&', '').trim()
+}
+
+function getDeepestNode<T extends Container>(node: T): Container {
   if (node.nodes && node.nodes.length) {
-    return getDeepestNode(node.nodes[node.nodes.length - 1] as AtRule | Rule)
+    return getDeepestNode(node.nodes[node.nodes.length - 1] as Container)
   }
   return node
 }

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -66,7 +66,7 @@
     "picomatch": "4.0.4",
     "pkg-types": "2.3.0",
     "pluralize": "8.0.0",
-    "postcss": "8.5.14",
+    "postcss": "8.5.25",
     "ts-morph": "28.0.0",
     "ts-pattern": "5.9.0"
   },

--- a/packages/postcss/package.json
+++ b/packages/postcss/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "@bamboocss/node": "workspace:*",
-    "postcss": "8.5.14"
+    "postcss": "8.5.25"
   },
   "devDependencies": {
     "@bamboocss/logger": "workspace:*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -230,7 +230,7 @@ importers:
         version: link:../types
       '@csstools/postcss-cascade-layers':
         specifier: 5.0.2
-        version: 5.0.2(postcss@8.5.14)
+        version: 5.0.2(postcss@8.5.25)
       browserslist:
         specifier: 4.28.1
         version: 4.28.1
@@ -241,23 +241,23 @@ importers:
         specifier: 0.8.0
         version: 0.8.0
       postcss:
-        specifier: 8.5.14
-        version: 8.5.14
+        specifier: 8.5.25
+        version: 8.5.25
       postcss-discard-duplicates:
         specifier: 7.0.2
-        version: 7.0.2(postcss@8.5.14)
+        version: 7.0.2(postcss@8.5.25)
       postcss-discard-empty:
         specifier: 7.0.1
-        version: 7.0.1(postcss@8.5.14)
+        version: 7.0.1(postcss@8.5.25)
       postcss-minify-selectors:
         specifier: 7.0.5
-        version: 7.0.5(postcss@8.5.14)
+        version: 7.0.5(postcss@8.5.25)
       postcss-nested:
         specifier: 7.0.2
-        version: 7.0.2(postcss@8.5.14)
+        version: 7.0.2(postcss@8.5.25)
       postcss-normalize-whitespace:
         specifier: 7.0.1
-        version: 7.0.1(postcss@8.5.14)
+        version: 7.0.1(postcss@8.5.25)
       postcss-selector-parser:
         specifier: 7.1.1
         version: 7.1.1
@@ -363,8 +363,8 @@ importers:
         specifier: workspace:*
         version: link:../types
       postcss:
-        specifier: 8.5.14
-        version: 8.5.14
+        specifier: 8.5.25
+        version: 8.5.25
 
   packages/generator:
     dependencies:
@@ -396,8 +396,8 @@ importers:
         specifier: 8.0.0
         version: 8.0.0
       postcss:
-        specifier: 8.5.14
-        version: 8.5.14
+        specifier: 8.5.25
+        version: 8.5.25
       ts-pattern:
         specifier: 5.9.0
         version: 5.9.0
@@ -533,8 +533,8 @@ importers:
         specifier: 8.0.0
         version: 8.0.0
       postcss:
-        specifier: 8.5.14
-        version: 8.5.14
+        specifier: 8.5.25
+        version: 8.5.25
       ts-morph:
         specifier: 28.0.0
         version: 28.0.0
@@ -641,8 +641,8 @@ importers:
         specifier: workspace:*
         version: link:../node
       postcss:
-        specifier: 8.5.14
-        version: 8.5.14
+        specifier: 8.5.25
+        version: 8.5.25
     devDependencies:
       '@bamboocss/logger':
         specifier: workspace:*
@@ -12949,6 +12949,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   nanoid@5.1.6:
     resolution: {integrity: sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg==}
     engines: {node: ^18 || >=20}
@@ -14522,6 +14527,10 @@ packages:
 
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.25:
+    resolution: {integrity: sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==}
     engines: {node: ^10 || ^12 || >=14}
 
   preact@10.27.2:
@@ -19538,6 +19547,12 @@ snapshots:
     dependencies:
       '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.1)
       postcss: 8.5.14
+      postcss-selector-parser: 7.1.1
+
+  '@csstools/postcss-cascade-layers@5.0.2(postcss@8.5.25)':
+    dependencies:
+      '@csstools/selector-specificity': 5.0.0(postcss-selector-parser@7.1.1)
+      postcss: 8.5.25
       postcss-selector-parser: 7.1.1
 
   '@csstools/postcss-color-function-display-p3-linear@1.0.1(postcss@8.5.14)':
@@ -32420,6 +32435,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@3.3.17: {}
+
   nanoid@5.1.6: {}
 
   nanotar@0.2.0: {}
@@ -33786,6 +33803,10 @@ snapshots:
     dependencies:
       postcss: 8.5.14
 
+  postcss-discard-duplicates@7.0.2(postcss@8.5.25):
+    dependencies:
+      postcss: 8.5.25
+
   postcss-discard-empty@5.1.1(postcss@8.5.14):
     dependencies:
       postcss: 8.5.14
@@ -33797,6 +33818,10 @@ snapshots:
   postcss-discard-empty@7.0.1(postcss@8.5.14):
     dependencies:
       postcss: 8.5.14
+
+  postcss-discard-empty@7.0.1(postcss@8.5.25):
+    dependencies:
+      postcss: 8.5.25
 
   postcss-discard-overridden@5.1.0(postcss@8.5.14):
     dependencies:
@@ -34019,6 +34044,12 @@ snapshots:
       postcss: 8.5.14
       postcss-selector-parser: 7.1.1
 
+  postcss-minify-selectors@7.0.5(postcss@8.5.25):
+    dependencies:
+      cssesc: 3.0.0
+      postcss: 8.5.25
+      postcss-selector-parser: 7.1.1
+
   postcss-modules-extract-imports@3.1.0(postcss@8.5.14):
     dependencies:
       postcss: 8.5.14
@@ -34052,9 +34083,9 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.14)
       string-hash: 1.1.3
 
-  postcss-nested@7.0.2(postcss@8.5.14):
+  postcss-nested@7.0.2(postcss@8.5.25):
     dependencies:
-      postcss: 8.5.14
+      postcss: 8.5.25
       postcss-selector-parser: 7.1.1
 
   postcss-nesting@13.0.2(postcss@8.5.14):
@@ -34198,6 +34229,11 @@ snapshots:
   postcss-normalize-whitespace@7.0.1(postcss@8.5.14):
     dependencies:
       postcss: 8.5.14
+      postcss-value-parser: 4.2.0
+
+  postcss-normalize-whitespace@7.0.1(postcss@8.5.25):
+    dependencies:
+      postcss: 8.5.25
       postcss-value-parser: 4.2.0
 
   postcss-opacity-percentage@3.0.0(postcss@8.5.14):
@@ -34422,6 +34458,12 @@ snapshots:
   postcss@8.5.14:
     dependencies:
       nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.25:
+    dependencies:
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 


### PR DESCRIPTION
## Problem

A semantic token declared with a conditional value emits only its `base` half. The conditional half never reaches the tokens layer — no error, no warning — so a themed app silently keeps its light values in dark mode.

```ts
// bamboo.config.ts
export default defineConfig({
  presets: ['@bamboocss/preset-base'],
  theme: {
    extend: {
      semanticTokens: {
        colors: {
          panel: { value: { base: '#ffffff', _osDark: '#131211' } },
        },
      },
    },
  },
})
```

```
bamboo codegen && bamboo cssgen tokens --outfile tokens.css
```

```css
/* actual — #131211 appears nowhere */
@layer tokens {
  :where(:root, :host) {
    --colors-panel: #ffffff;
}
}
```

Not specific to `_osDark` — `_dark` and `_print` fail identically, so it isn't an at-rule vs. selector issue. The token dictionary is fine (`tokens.view.vars` has both `base` and `_osDark` keys, and `extensions.conditions` holds both values); only the CSS emission drops it.

## Cause

`getDeepestRule` seeds its nesting chain with an empty-selector rule and leans on postcss-nested to erase `&` against it:

```ts
const rule = postcss.rule({ selector: '' })
…
const atRule = postcss.rule({ selector, nodes: [postcss.rule({ selector: `${root}&` })] })
```

postcss **8.5.25** ("Fixed 8.5.17 visitor regression" — postcss-nested is a visitor plugin) changed that edge case to collapse the whole selector, so the rule is emitted selectorless and discarded downstream. Running the two functions in isolation, holding postcss-nested at 7.0.2 and varying only postcss:

| postcss | result |
| --- | --- |
| 8.4.31, 8.5.14, 8.5.19–8.5.24 | `@media (…) { :where(:root, :host) { --x } }` |
| **8.5.25** | `@media (…) { { --x } }` ← selector gone |

I bisected 8.5.20 → 8.5.25 one version at a time; it lands exactly on 8.5.25. Since that is the current latest, this is about to hit everyone using conditional tokens.

## Fix

Build the chain on a `Root` — the proper container — and resolve the top-level `&` directly rather than through postcss-nested. Deeper segments keep their `&` and nest against a real parent selector, so chained/multi-block conditions are unchanged.

The output is now byte-identical across postcss 8.5.14 and 8.5.25 for at-rule, selector, and chained conditions.

## About the snapshot churn

36 snapshot lines change and **every one differs only in whitespace** — I verified this mechanically rather than by eye (normalise whitespace on both sides of the diff: 36 removed, 36 added, 0 differing by anything else). The empty-selector wrapper had been contributing a phantom indent level to the emitted CSS; without it the closing braces sit one level shallower. No selector or declaration changes.

## Second commit — the postcss bump

`build(deps): bump postcss to 8.5.25` is separate so you can drop it if you'd rather not take the bump here.

It matters because the repo pins postcss 8.5.14, where the old empty-parent behaviour still happened to work — so **without the bump nothing in CI guards this regression**, and the added test passes either way. With the bump:

| | postcss 8.5.14 | postcss 8.5.25 |
| --- | --- | --- |
| before fix | 160 pass | **14 snapshots fail** |
| after fix | 161 pass | 161 pass |

Full suite on the bumped version with the fix: **228 files, 2169 passed, 1 skipped, 0 failed**. `pnpm lint` and `pnpm typecheck` clean. The lockfile diff is entirely postcss version lines.

## Test

`conditional semantic tokens keep their selector` in `generate-token.test.ts` covers both an at-rule condition (`_osDark`) and a selector condition (`_dark`), and asserts the invariant directly — every emitted rule must carry a selector, since a selectorless one is dropped by any downstream parser and takes the conditional value with it.

## How this surfaced

A dark-mode UI where backgrounds never switched while call-site `_osDark` styles did — the utility path emits conditions correctly, so only the token-driven half of the theme was stuck on its light values.
